### PR TITLE
Simple variable stack implementation

### DIFF
--- a/examples/11-variables.pasm
+++ b/examples/11-variables.pasm
@@ -1,0 +1,9 @@
+label entry
+
+    push 1
+    stor test ; now the value 1 poped from the stack is stored in the variable test
+    push 2
+
+    load test ; the value stored in the variable test is loaded to the stack
+    print
+    pop ; poped the value 2 that was left unchenged

--- a/vm/nim/compile.nim
+++ b/vm/nim/compile.nim
@@ -77,6 +77,14 @@ proc compile*(m: Machine, source: string) =
             of "lteq": m.program.instructions.add(Instruction(loc: lineCount, kind: Cmp, cmp_kind: Cmp_LtEq))
             of "gteq": m.program.instructions.add(Instruction(loc: lineCount, kind: Cmp, cmp_kind: Cmp_GtEq))
             else: m.log(lineCount, Log_Error, fmt"COMPILE: Unknown operand `{parts[1]}` for `cmp` instruction")
+        
+        of Stor:
+            if parts.len < 1: m.log(lineCount, Log_Error, "COMPILE: Missing operand for `stor` instruction")
+            m.program.instructions.add(Instruction(loc: lineCount, kind: Stor, key: parts[1]))
+
+        of Load:
+            if parts.len < 1: m.log(lineCount, Log_Error, "COMPILE: Missing operand for `load` instruction")
+            m.program.instructions.add(Instruction(loc: lineCount, kind: Load, key: parts[1]))
 
         of Cast:
             if parts.len < 2 or parts[1].len == 0: m.log(lineCount, Log_Error, "COMPILE: Missing operand for `cast` instruction")

--- a/vm/nim/execute.nim
+++ b/vm/nim/execute.nim
@@ -105,6 +105,17 @@ proc execute*(m: Machine) =
                     of VK_String: m.log(instruction.loc, Log_Error, fmt"EXECUTE: Comparison is not allowed for `{VK_String}`")
                     of VK_Int: m.stack.add(Value(kind: VK_Int, i: if a.i <= b.i: 1 else: 0))
 
+        of Stor:
+            if m.stack.len == 0: m.log(instruction.loc, Log_Error, fmt"EXECUTE: No value on stack to store")
+
+            let value = m.general_stack.pop()
+            m.variables[instruction.key] = value
+
+        of Load:
+            if instruction.key notin m.variables: m.log(instruction.loc, Log_Error, fmt"EXECUTE: Variable `{instruction.key}` not found")
+
+            m.general_stack.add(m.variables[instruction.key])
+
         of Cast:
             if m.stack.len == 0: m.log(instruction.loc, Log_Error, fmt"EXECUTE: No value on stack to cast")
 

--- a/vm/nim/types.nim
+++ b/vm/nim/types.nim
@@ -44,6 +44,7 @@ type
         Print,
         Label, Jump, EqJump, NeqJump, LtJump, GtJump,
         Call, Proc, ProcReturn, ProcArgs, ProcReturnArgs,
+        Stor, Load,
         Unknown, Exit,
 
 proc instructionKindFromString*(s: string): InstructionKind =
@@ -69,6 +70,9 @@ proc instructionKindFromString*(s: string): InstructionKind =
     of "neqjump": return NeqJump
     of "ltjump": return LtJump
     of "gtjump": return GtJump
+
+    of "stor": return Stor
+    of "load": return Load
     
     of "call": return Call
     of "proc": return Proc
@@ -106,6 +110,8 @@ type
         of Jump, EqJump, NeqJump, LtJump, GtJump:
             name_target*: string
             target*: int
+        of Stor, Load:
+            key*: string
         of Exit:
             exit_code*: int
         of Unknown, Print, Add, Sub, Mul, Div, Mod, Comment:
@@ -153,6 +159,7 @@ type
         
         procs*: Table[string, int] = initTable[string, int]()
         labels*: Table[string, int] = initTable[string, int]()
+        variables*: Table[string, Value] = initTable[string, Value]()
 
         general_stack*: Stack = Stack(name: "general")
         procedures_stack*: seq[ProcedureStack] = @[]


### PR DESCRIPTION
It was added a way to store values outside the stack, for a more long term use.

The implementation uses a table that stores the values as string keys in a std/table.

The instructions `stor`and `load` was created for manipulate the table. They receives a param that don't need to be surrounded by quotes. Even though it can, because de function do not care, and will uses the quotes as part of the table key

Example added to exemplify:
```
label entry

    push 1
    stor test ; now the value 1 poped from the stack is stored in the variable test
    push 2

    load test ; the value stored in the variable test is loaded to the stack
    print ; 1 is printed
    pop ; poped the value 2 that was left unchenged
```